### PR TITLE
Skip DB authentication

### DIFF
--- a/lib/ernest.rb
+++ b/lib/ernest.rb
@@ -39,15 +39,15 @@ class Ernest < Sinatra::Base
 
   helpers do
     def valid_key?
-      @user = User.find_by_api_key(request.env["HTTP_ACCESS_TOKEN"])
-      !@user.nil?
+      @token = request.env["HTTP_ACCESS_TOKEN"]
+      ENV['ERNEST_ALLOWED_KEYS'].split(",").include?(@token)
     end
   end
 
   post '/addresses', check: :valid_key? do
     body = JSON.parse request.body.read
 
-    CreateAddress.perform_async(body, @user.id)
+    CreateAddress.perform_async(body, @token)
 
     return 202
   end

--- a/lib/jobs/create_address.rb
+++ b/lib/jobs/create_address.rb
@@ -1,12 +1,12 @@
 class CreateAddress
   include Sidekiq::Worker
 
-  def perform(body, user_id)
+  def perform(body, token)
     ActiveRecord::Base.transaction do
       body['addresses'].each do |a|
         provenance = create_provenance(a['provenance'])
         address = Address.new(activity_attributes: provenance)
-        address.user = User.find(user_id)
+        address.user = User.find_by_api_key(token)
 
         a['address'].each do |type, label|
           tag_type = TagType.find_or_create_by(label: type)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -4,6 +4,7 @@ describe Ernest do
 
   before(:all) do
     @user = FactoryGirl.create(:user)
+    ENV['ERNEST_ALLOWED_KEYS'] = @user.api_key
     @body = {
       addresses: [
         {
@@ -41,7 +42,7 @@ describe Ernest do
   it "should queue a CreateAddress job" do
     post 'addresses', @body, { "HTTP_ACCESS_TOKEN" => @user.api_key }
 
-    expect(CreateAddress).to have_enqueued_job(JSON.parse(@body), @user.id)
+    expect(CreateAddress).to have_enqueued_job(JSON.parse(@body), @user.api_key)
     expect(last_response.status).to eq(202)
   end
 

--- a/spec/jobs/create_address_spec.rb
+++ b/spec/jobs/create_address_spec.rb
@@ -35,7 +35,7 @@ describe CreateAddress do
 
   it "should create an address" do
     worker = CreateAddress.new
-    worker.perform(JSON.parse(@body), @user.id)
+    worker.perform(JSON.parse(@body), @user.api_key)
 
     expect(Address.count).to eq(1)
 
@@ -59,7 +59,7 @@ describe CreateAddress do
       ]
     }
 
-    worker.perform(body, @user.id)
+    worker.perform(body, @user.api_key)
 
     expect(Address.count).to eq(1)
 
@@ -147,14 +147,14 @@ describe CreateAddress do
 
     worker = CreateAddress.new
 
-    worker.perform(JSON.parse(body), @user.id)
+    worker.perform(JSON.parse(body), @user.api_key)
 
     expect(Address.count).to eq(3)
   end
 
   it "should apply a user" do
     worker = CreateAddress.new
-    worker.perform(JSON.parse(@body), @user.id)
+    worker.perform(JSON.parse(@body), @user.api_key)
 
     expect(Address.last.user).to eq(@user)
   end


### PR DESCRIPTION
I've added a new ENV variable - `ERNEST_ALLOWED_KEYS`, basically a comma seperated list of keys, so we can skip DB calls when authenticating. Need to add this to Heroku (which I'll do now), but then we can crack on.
