### PR TITLE
Load fixed provenance

### DIFF
--- a/config/fixed_provenance_sources.json
+++ b/config/fixed_provenance_sources.json
@@ -1,0 +1,48 @@
+[
+  {
+    "type": "Source",
+    "description_url": "http://download.companieshouse.gov.uk/en_output.html",
+    "url": [
+      "http://download.companieshouse.gov.uk/BasicCompanyData-2014-11-01-part1_5.zip",
+      "http://download.companieshouse.gov.uk/BasicCompanyData-2014-11-01-part2_5.zip",
+      "http://download.companieshouse.gov.uk/BasicCompanyData-2014-11-01-part3_5.zip",
+      "http://download.companieshouse.gov.uk/BasicCompanyData-2014-11-01-part4_5.zip",
+      "http://download.companieshouse.gov.uk/BasicCompanyData-2014-11-01-part5_5.zip"
+    ],
+    "name": "Companies House's \"Free Company Data Product\"",
+    "executed_at": "2014-11-19T09:30:00Z",
+    "processing_scripts": "https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/CH_download.py"
+  },
+  {
+    "type": "Source",
+    "name": "Ordnance Survey's \"Locator\" open data product",
+    "description_url": "http://www.ordnancesurvey.co.uk/business-and-government/products/os-locator.html",
+    "url": [
+      "http://openaddressesuk.github.io/OS_Locator/OS_Locator2014_2_OPEN_xaa.txt", 
+      "http://openaddressesuk.github.io/OS_Locator/OS_Locator2014_2_OPEN_xab.txt", 
+      "http://openaddressesuk.github.io/OS_Locator/OS_Locator2014_2_OPEN_xac.txt", 
+      "http://openaddressesuk.github.io/OS_Locator/OS_Locator2014_2_OPEN_xad.txt"
+    ],
+    "executed_at": "2014-11-19T09:30:00Z",
+    "processing_scripts": "https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/OS_Locator_download.py"
+  },
+  {
+    "type": "Source",
+    "name": "Wikipedia",
+    "url": [
+      "http://en.wikipedia.org/wiki/List_of_post_towns_in_the_United_Kingdom"
+    ],
+    "executed_at": "2014-11-19T09:30:00Z",
+    "processing_scripts": "https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/OA_Posttowns.py"
+  },
+  {
+    "type": "Source",
+    "description_url": "http://www.ons.gov.uk/ons/guide-method/geography/products/postcode-directories/-nspp-/index.html",
+    "name": "Office for National Statistics' \"ONS Postcode Directory (ONSPD)\" open data product",
+    "url": [
+      "https://geoportal.statistics.gov.uk/Docs/PostCodes/ONSPD_AUG_2014_csv.zip"
+    ],
+    "executed_at": "2014-11-19T09:30:00Z",
+    "processing_scripts": "https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/ONSPD_download.py"
+  }
+]

--- a/lib/ernest.rb
+++ b/lib/ernest.rb
@@ -73,10 +73,12 @@ class Ernest < Sinatra::Base
           h[l]["geometry"]["coordinates"] = [point.y, point.x]
         end
       end
+      fixed_provenance_sources = JSON.parse(File.read('config/fixed_provenance_sources.json'))
       h['provenance'] = {
         activity: {
+          processing_script: "https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/CH_Bulk_Extractor.py",
           executed_at: a.activity.executed_at,
-          derived_from: a.activity.derivations.map { |d| { type: d.entity_type, url: d.entity.url } }
+          derived_from: fixed_provenance_sources
         }
       }
       addresses << h

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -173,21 +173,8 @@ describe Ernest do
     get 'addresses'
     response = JSON.parse last_response.body
 
-    expect(response['addresses'].last).to include(
-      {
-        "provenance" => {
-          "activity" => {
-          "executed_at" => "2014-01-01T11:00:00.000Z",
-            "derived_from" => [
-              {
-              "type" => "Source",
-              "url" => "http://example.com"
-              }
-            ]
-          }
-        }
-      }
-    )
+    expect(response['addresses'].last["provenance"]["activity"]["processing_script"]).to eq("https://github.com/OpenAddressesUK/common-ETL/blob/efcd9970fc63c12b2f1aef410f87c2dcb4849aa3/CH_Bulk_Extractor.py")
+    expect(response['addresses'].last["provenance"]["activity"]["derived_from"].length).to be(4)
 
     Timecop.return
   end


### PR DESCRIPTION
For now, provenance data is fixed state, so we just load it from a JSON file. Ernest is quite capable of representing all this internally, but we don't have the data coming in via the API right now.
